### PR TITLE
Implement stun skip logic

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -56,9 +56,12 @@ namespace _Core._Combat.Services
                 var entity = combatants[_current];
                 await entity.OnTurnStart(config);
 
-                if (entity.GetComponent<StatusController>()?.IsStunned == true)
+                var status = entity.GetComponent<StatusController>();
+                if (status != null && status.SkipNextTurn)
                 {
+                    status.SkipNextTurn = false;
                     _current = (_current + 1) % combatants.Count;
+                    await UniTask.Yield();
                     continue;
                 }
 

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusController.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusController.cs
@@ -16,6 +16,13 @@ namespace _Core._Combat
         private readonly List<ActiveStatus> _statuses = new();
         private StatusIndicator _indicator;
 
+        /// <summary>
+        /// When true, the owning entity should skip its upcoming turn.
+        /// This flag is set when a <see cref="StatusType.Stun"/> is applied
+        /// and consumed by <see cref="CombatService"/> after the turn is skipped.
+        /// </summary>
+        public bool SkipNextTurn { get; set; }
+
         private void Awake()
         {
             _indicator = GetComponent<StatusIndicator>();
@@ -41,6 +48,10 @@ namespace _Core._Combat
                     ShieldLeft = effect.Value
                 });
             }
+            if (effect.Type == StatusType.Stun)
+            {
+                SkipNextTurn = true;
+            }
             _indicator?.SetStatus(effect.Type, true);
         }
 
@@ -58,7 +69,9 @@ namespace _Core._Combat
                         entity.Resources.Health += s.Effect.Value;
                         break;
                     case StatusType.Stun:
-                        // just consume duration
+                        // Stun effects simply reduce their duration here.
+                        // SkipNextTurn is handled separately until the combat
+                        // loop consumes it.
                         break;
                 }
 


### PR DESCRIPTION
## Summary
- extend `StatusController` with `SkipNextTurn` property
- flag SkipNextTurn whenever a stun status is applied
- update combat turn sequence to honour SkipNextTurn instead of IsStunned

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*