### PR TITLE
Handle dead combatants in battle loop

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatEntity.cs
@@ -7,6 +7,7 @@ namespace _Core._Combat
     {
         string Id { get; }
         bool IsPlayer { get; }
+        bool IsAlive { get; }
         StatBlock Stats { get; }
         ResourcePool Resources { get; }
         UniTask OnTurnStart(BattleConfig config);
@@ -27,6 +28,7 @@ namespace _Core._Combat
 
         public string Id => id;
         public bool IsPlayer => isPlayer;
+        public bool IsAlive => resources.Health > 0;
         public StatBlock Stats => stats;
         public ResourcePool Resources => resources;
         public Transform Transform => transform;


### PR DESCRIPTION
## Summary
- add `IsAlive` to `ICombatEntity` and `CombatEntity`
- skip dead entities at the start of each battle round
- filter out dead targets when selecting enemies
- rely on `IsAlive` when checking for battle end

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*