### PR TITLE
Fix enemy selection to ignore dead units

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -98,7 +98,9 @@ namespace _Core._Combat.Services
                 case TargetSelector.Self:
                     return new ICombatEntity[] { source };
                 case TargetSelector.SingleEnemy:
-                    var enemies = combatants.Where(c => c.IsPlayer != source.IsPlayer).ToList();
+                    var enemies = combatants
+                        .Where(c => c.IsPlayer != source.IsPlayer && c.Resources.Health > 0)
+                        .ToList();
                     if (source.IsPlayer && ability.MaxTargets > 1)
                     {
                         var selector = source.GetComponent<TargetSelectionController>();
@@ -108,7 +110,10 @@ namespace _Core._Combat.Services
                     var enemy = enemies.FirstOrDefault();
                     return enemy != null ? new ICombatEntity[] { enemy } : new ICombatEntity[] { source };
                 case TargetSelector.AllEnemies:
-                    return combatants.Where(c => c.IsPlayer != source.IsPlayer).Cast<ICombatEntity>().ToList();
+                    return combatants
+                        .Where(c => c.IsPlayer != source.IsPlayer && c.Resources.Health > 0)
+                        .Cast<ICombatEntity>()
+                        .ToList();
                 default:
                     return new ICombatEntity[] { source };
             }


### PR DESCRIPTION
## Summary
- ensure CombatService ignores dead enemies when selecting targets

## Testing
- `true`
