### PR TITLE
Implement ability cost check for CombatEntity

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatEntity.cs
@@ -69,6 +69,15 @@ namespace _Core._Combat
             return UniTask.CompletedTask;
         }
 
+        public bool CanUse(AbilitySO ability)
+        {
+            if (ability == null)
+                return false;
+
+            return resources.Mana >= ability.CostMana &&
+                   resources.Stamina >= ability.CostStamina;
+        }
+
         public abstract UniTask<AbilitySO> SelectAbility();
     }
 }

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/EnemyEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/EnemyEntity.cs
@@ -17,7 +17,7 @@ namespace _Core._Combat
             {
                 var ability = behaviour.Abilities[_index];
                 _index = (_index + 1) % behaviour.Abilities.Count;
-                if (!IsOnCooldown(ability))
+                if (!IsOnCooldown(ability) && CanUse(ability))
                     return UniTask.FromResult(ability);
             }
 

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
@@ -28,15 +28,15 @@ namespace _Core._Combat
         {
             var list = new List<AbilitySO>();
             foreach (var a in abilities)
-                if (!IsOnCooldown(a))
+                if (!IsOnCooldown(a) && CanUse(a))
                     list.Add(a);
             if (_config && Resources.UltimateCharge >= 100f && _config.UltimateAbility)
-                if (!IsOnCooldown(_config.UltimateAbility))
+                if (!IsOnCooldown(_config.UltimateAbility) && CanUse(_config.UltimateAbility))
                     list.Add(_config.UltimateAbility);
 
             if (_potionController)
                 foreach (var a in _potionController.ActiveAbilities)
-                    if (!IsOnCooldown(a))
+                    if (!IsOnCooldown(a) && CanUse(a))
                         list.Add(a);
 
             if (_selectionPanel == null || list.Count == 0)


### PR DESCRIPTION
## Summary
- add CanUse to CombatEntity to check resources vs ability costs
- filter abilities in PlayerEntity and EnemyEntity based on new CanUse method

## Testing
- `dotnet test` *(fails: command not found)*