### PR TITLE
Add ability resolved event for updating HUD

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -21,8 +21,10 @@ namespace _Core._Combat.Services
 
     public interface ICombatService : IService
     {
-        public void Configure(BattleConfig cfg, IList<CombatEntity> list);
-        public UniTask StartBattle(System.Threading.CancellationToken token);
+        event System.Action OnAbilityResolved;
+
+        void Configure(BattleConfig cfg, IList<CombatEntity> list);
+        UniTask StartBattle(System.Threading.CancellationToken token);
     }
 
     [DependsOn(typeof(ICameraService), typeof(IEquipService))]
@@ -34,6 +36,10 @@ namespace _Core._Combat.Services
         private int _current;
         private BattleState _state;
         public BattleState State => _state;
+
+        public event System.Action OnAbilityResolved;
+
+        private void RaiseAbilityResolved() => OnAbilityResolved?.Invoke();
 
         public override async UniTask OnStart()
         {
@@ -83,6 +89,7 @@ namespace _Core._Combat.Services
                     }
 
                     entity.Resources.Clamp(entity.Stats);
+                    RaiseAbilityResolved();
                 }
 
                 _state = DetermineBattleState();

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/BattleHUD.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/BattleHUD.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
+using _Core._Combat.Services;
+using _Core._Global.Services;
 
 namespace _Core._Combat.UI
 {
@@ -25,6 +27,21 @@ namespace _Core._Combat.UI
         private PlayerEntity _player;
 
         private readonly List<Button> _spawnedAbilities = new();
+
+        private ICombatService _combatService;
+
+        private void OnEnable()
+        {
+            _combatService = GService.GetService<ICombatService>();
+            if (_combatService != null)
+                _combatService.OnAbilityResolved += UpdateBars;
+        }
+
+        private void OnDisable()
+        {
+            if (_combatService != null)
+                _combatService.OnAbilityResolved -= UpdateBars;
+        }
 
         public void BindPlayer(PlayerEntity player)
         {


### PR DESCRIPTION
## Summary
- add `OnAbilityResolved` event in `CombatService`
- raise event after an ability resolves
- subscribe `BattleHUD` to update bars when abilities resolve

## Testing
- `dotnet test` *(fails: `dotnet` not found)*