### PR TITLE
Improve battle HUD and targeting

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySO.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySO.cs
@@ -21,6 +21,7 @@ namespace _Core._Combat
     [CreateAssetMenu(fileName = "Ability", menuName = "Combat/Ability")]
     public class AbilitySO : ScriptableObject
     {
+        public Sprite Icon;
         public int PhysicalDamage;
         public int MagicalDamage;
         public int CostMana;

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySelectionPanel.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySelectionPanel.cs
@@ -1,18 +1,17 @@
 using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
-using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
+using _Core._Combat.UI;
 
 namespace _Core._Combat
 {
     public class AbilitySelectionPanel : MonoBehaviour
     {
-        [SerializeField] private Button abilityButtonPrefab;
+        [SerializeField] private AbilityButton abilityButtonPrefab;
         [SerializeField] private Transform container;
 
-        private readonly List<Button> _spawned = new();
+        private readonly List<AbilityButton> _spawned = new();
         private UniTaskCompletionSource<AbilitySO> _tcs;
 
         public async UniTask<AbilitySO> ChooseAbility(IReadOnlyList<AbilitySO> abilities, Func<AbilitySO, int> cooldownProvider = null)
@@ -23,9 +22,8 @@ namespace _Core._Combat
             {
                 var btn = Instantiate(abilityButtonPrefab, container);
                 var cd = cooldownProvider?.Invoke(ability) ?? 0;
-                btn.GetComponentInChildren<TextMeshProUGUI>().text = cd > 0 ? $"{ability.name} ({cd})" : ability.name;
-                btn.interactable = cd <= 0;
-                btn.onClick.AddListener(() => Select(ability));
+                btn.Setup(ability, cd);
+                btn.Button.onClick.AddListener(() => Select(ability));
                 _spawned.Add(btn);
             }
             return await _tcs.Task;

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/ClickableTarget.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/ClickableTarget.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace _Core._Combat
+{
+    /// <summary>
+    /// Simple component that raises an event when the entity is clicked.
+    /// Requires a collider.
+    /// </summary>
+    public class ClickableTarget : MonoBehaviour
+    {
+        public event System.Action<CombatEntity> OnClicked;
+
+        private CombatEntity _entity;
+
+        private void Awake()
+        {
+            _entity = GetComponent<CombatEntity>();
+        }
+
+        private void OnMouseDown()
+        {
+            if (_entity != null)
+                OnClicked?.Invoke(_entity);
+        }
+    }
+}

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusController.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusController.cs
@@ -52,7 +52,7 @@ namespace _Core._Combat
             {
                 SkipNextTurn = true;
             }
-            _indicator?.SetStatus(effect.Type, true);
+            _indicator?.AddStatus(effect);
         }
 
         public void TickStartTurn(CombatEntity entity)
@@ -79,7 +79,7 @@ namespace _Core._Combat
                 if (s.Remaining <= 0 || (s.Effect.Type == StatusType.Shield && s.ShieldLeft <= 0))
                 {
                     _statuses.RemoveAt(i);
-                    _indicator?.SetStatus(s.Effect.Type, false);
+                    _indicator?.RemoveStatus(s.Effect.Type);
                 }
             }
             entity.Resources.Clamp(entity.Stats);
@@ -102,7 +102,8 @@ namespace _Core._Combat
                 if (_statuses[i].Effect.Type == type)
                     _statuses.RemoveAt(i);
             }
-            _indicator?.SetStatus(type, _statuses.Any(s => s.Effect.Type == type));
+            if (!_statuses.Any(s => s.Effect.Type == type))
+                _indicator?.RemoveStatus(type);
         }
     }
 }

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusEffectSO.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusEffectSO.cs
@@ -13,6 +13,7 @@ namespace _Core._Combat
     [CreateAssetMenu(fileName = "StatusEffect", menuName = "Combat/Status Effect")]
     public class StatusEffectSO : ScriptableObject
     {
+        public Sprite Icon;
         public StatusType Type;
         public int Value;
         public int Duration;

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusIndicator.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/StatusIndicator.cs
@@ -1,36 +1,39 @@
 using System.Collections.Generic;
 using UnityEngine;
+using _Core._Combat.UI;
 
 namespace _Core._Combat
 {
     /// <summary>
-    /// Displays active status icons. This is a simple placeholder implementation.
+    /// Spawns status icons for active effects.
     /// </summary>
     public class StatusIndicator : MonoBehaviour
     {
-        [SerializeField] private GameObject poisonIcon;
-        [SerializeField] private GameObject regenIcon;
-        [SerializeField] private GameObject stunIcon;
-        [SerializeField] private GameObject shieldIcon;
+        [SerializeField] private Transform container;
+        [SerializeField] private StatusIcon iconPrefab;
 
-        private readonly Dictionary<StatusType, GameObject> _icons = new();
+        private readonly Dictionary<StatusType, StatusIcon> _icons = new();
 
-        private void Awake()
+        public void AddStatus(StatusEffectSO effect)
         {
-            if (poisonIcon) poisonIcon.SetActive(false);
-            if (regenIcon) regenIcon.SetActive(false);
-            if (stunIcon) stunIcon.SetActive(false);
-            if (shieldIcon) shieldIcon.SetActive(false);
-            _icons[StatusType.Poison] = poisonIcon;
-            _icons[StatusType.Regen] = regenIcon;
-            _icons[StatusType.Stun] = stunIcon;
-            _icons[StatusType.Shield] = shieldIcon;
+            if (effect == null || _icons.ContainsKey(effect.Type))
+                return;
+            if (iconPrefab == null || container == null)
+                return;
+
+            var icon = Instantiate(iconPrefab, container);
+            icon.SetIcon(effect.Icon);
+            _icons[effect.Type] = icon;
         }
 
-        public void SetStatus(StatusType type, bool active)
+        public void RemoveStatus(StatusType type)
         {
-            if (_icons.TryGetValue(type, out var go) && go != null)
-                go.SetActive(active);
+            if (_icons.TryGetValue(type, out var icon))
+            {
+                if (icon)
+                    Destroy(icon.gameObject);
+                _icons.Remove(type);
+            }
         }
     }
 }

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/AbilityButton.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/AbilityButton.cs
@@ -1,0 +1,32 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace _Core._Combat.UI
+{
+    /// <summary>
+    /// Visual representation for an ability choice.
+    /// Displays icon, name and cooldown state.
+    /// </summary>
+    public class AbilityButton : MonoBehaviour
+    {
+        [SerializeField] private Button button;
+        [SerializeField] private Image icon;
+        [SerializeField] private TextMeshProUGUI label;
+        [SerializeField] private TextMeshProUGUI cooldownLabel;
+
+        public Button Button => button;
+
+        public void Setup(AbilitySO ability, int cooldown)
+        {
+            if (label) label.text = ability ? ability.name : string.Empty;
+            if (icon) icon.sprite = ability ? ability.Icon : null;
+            if (cooldownLabel)
+            {
+                cooldownLabel.gameObject.SetActive(cooldown > 0);
+                if (cooldown > 0) cooldownLabel.text = cooldown.ToString();
+            }
+            if (button) button.interactable = cooldown <= 0;
+        }
+    }
+}

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/PotionButton.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/PotionButton.cs
@@ -1,0 +1,24 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace _Core._Combat.UI
+{
+    /// <summary>
+    /// Button for potion abilities shown in the HUD.
+    /// </summary>
+    public class PotionButton : MonoBehaviour
+    {
+        [SerializeField] private Button button;
+        [SerializeField] private Image icon;
+        [SerializeField] private TextMeshProUGUI label;
+
+        public Button Button => button;
+
+        public void Setup(PotionAbilitySO ability)
+        {
+            if (label) label.text = ability ? ability.name : string.Empty;
+            if (icon) icon.sprite = ability ? ability.Icon : null;
+        }
+    }
+}

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/StatusIcon.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/StatusIcon.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace _Core._Combat.UI
+{
+    /// <summary>
+    /// Visual icon for a status effect.
+    /// </summary>
+    public class StatusIcon : MonoBehaviour
+    {
+        [SerializeField] private Image icon;
+
+        public void SetIcon(Sprite sprite)
+        {
+            if (icon) icon.sprite = sprite;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add icons to AbilitySO and StatusEffectSO
- implement reusable AbilityButton, PotionButton and StatusIcon UI components
- update AbilitySelectionPanel to use AbilityButton
- dynamically spawn status icons
- add ClickableTarget for selecting enemies via clicks
- revamp TargetSelectionController for manual selection
- spawn BattleHUD with player and keep combatants parented to spawn points

## Testing
- `dotnet test` *(fails: dotnet not installed)*