### PR TITLE
Add end-turn waiting mechanics

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -101,6 +101,11 @@ namespace _Core._Combat.Services
                     RaiseAbilityResolved();
                 }
 
+                if (entity.IsPlayer && entity is PlayerEntity player)
+                {
+                    await player.WaitEndTurn();
+                }
+
                 _state = DetermineBattleState();
                 _current = (_current + 1) % combatants.Count;
                 await UniTask.Yield();

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
@@ -47,5 +47,10 @@ namespace _Core._Combat
             abilities = list?.ToArray() ?? System.Array.Empty<AbilitySO>();
         }
 
+        public UniTask WaitEndTurn()
+        {
+            return _hud != null ? _hud.WaitEndTurn() : UniTask.CompletedTask;
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- add `endTurnButton` field in BattleHUD and support waiting for click
- expose `WaitEndTurn` on PlayerEntity
- wait for player's end turn in CombatService

## Testing
- `No tests provided in repository`
