### PR TITLE
Handle potions without ending turn

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/PotionController.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/PotionController.cs
@@ -41,7 +41,8 @@ namespace _Core._Combat
 
         public void RegisterUse()
         {
-            _usedThisTurn++;
+            var limit = _config ? _config.PotionsPerTurn : 0;
+            _usedThisTurn = Mathf.Min(_usedThisTurn + 1, limit);
             OnUsesChanged?.Invoke(RemainingUses);
         }
 


### PR DESCRIPTION
## Summary
- allow combat turn to continue after using PotionAbilitySO
- clamp potion usage per turn

## Testing
- `dotnet` was not available and no Unity test runner in this environment
