### PR TITLE
Update battle flow to await turn end

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -66,6 +66,7 @@ namespace _Core._Combat.Services
             while (_state != BattleState.Victory && _state != BattleState.Defeat && !token.IsCancellationRequested)
             {
                 await RunTurn(player);
+                await player.WaitEndTurn();
                 _state = DetermineBattleState();
                 if (_state == BattleState.Victory || _state == BattleState.Defeat || token.IsCancellationRequested)
                     break;


### PR DESCRIPTION
## Summary
- wait for end-turn after the player's actions

## Testing
- `dotnet test` *(fails: command not found)*