### PR TITLE
Fix turn flow for combat system

### DIFF
--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySelectionPanel.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/AbilitySelectionPanel.cs
@@ -29,6 +29,12 @@ namespace _Core._Combat
             return await _tcs.Task;
         }
 
+        public void CancelSelection()
+        {
+            _tcs?.TrySetResult(null);
+            ClearButtons();
+        }
+
         private void Select(AbilitySO ability)
         {
             _tcs.TrySetResult(ability);

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/CombatService.cs
@@ -98,6 +98,18 @@ namespace _Core._Combat.Services
                 return;
             }
 
+            if (entity is PlayerEntity player)
+            {
+                await RunPlayerTurn(player);
+            }
+            else
+            {
+                await RunEnemyTurn(entity);
+            }
+        }
+
+        private async UniTask RunEnemyTurn(CombatEntity entity)
+        {
             var ability = await entity.SelectAbility();
             if (ability == null)
                 return;
@@ -106,6 +118,39 @@ namespace _Core._Combat.Services
             await AbilityExecutor.Execute(entity, targets, ability);
             entity.StartCooldown(ability);
 
+            ApplyPostAbility(entity, ability, targets.Count);
+        }
+
+        private async UniTask RunPlayerTurn(PlayerEntity player)
+        {
+            var endTurnTask = player.WaitEndTurn();
+
+            while (!endTurnTask.Status.IsCompleted)
+            {
+                if (!player.HasUsableAbility())
+                {
+                    player.ForceEndTurn();
+                    break;
+                }
+
+                var abilityTask = player.SelectAbility();
+                var (winner, ability, _) = await UniTask.WhenAny(abilityTask, endTurnTask);
+
+                if (winner == 1 || ability == null)
+                    break;
+
+                var targets = await SelectTargets(player, ability);
+                await AbilityExecutor.Execute(player, targets, ability);
+                player.StartCooldown(ability);
+
+                ApplyPostAbility(player, ability, targets.Count);
+            }
+
+            await endTurnTask;
+        }
+
+        private void ApplyPostAbility(CombatEntity entity, AbilitySO ability, int targetCount)
+        {
             if (ability == config.UltimateAbility)
             {
                 entity.Resources.UltimateCharge = 0f;
@@ -116,7 +161,7 @@ namespace _Core._Combat.Services
             }
             else if (ability.PhysicalDamage > 0 || ability.MagicalDamage > 0)
             {
-                entity.Resources.UltimateCharge += config.UltChargePerAttack * targets.Count;
+                entity.Resources.UltimateCharge += config.UltChargePerAttack * targetCount;
             }
 
             entity.Resources.Clamp(entity.Stats);

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/PlayerEntity.cs
@@ -52,5 +52,20 @@ namespace _Core._Combat
             return _hud != null ? _hud.WaitEndTurn() : UniTask.CompletedTask;
         }
 
+        public void ForceEndTurn()
+        {
+            _hud?.ForceEndTurn();
+        }
+
+        public bool HasUsableAbility()
+        {
+            if (CanUseUltimate())
+                return true;
+            foreach (var a in abilities)
+                if (!IsOnCooldown(a) && CanUse(a))
+                    return true;
+            return false;
+        }
+
     }
 }

--- a/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/BattleHUD.cs
+++ b/Hentai-Tavern/Assets/_Core/_Global/_Combat/UI/BattleHUD.cs
@@ -169,8 +169,14 @@ namespace _Core._Combat.UI
         {
             endTurnButton.onClick.RemoveListener(OnEndTurnClicked);
             endTurnButton.interactable = false;
+            abilityPanel?.CancelSelection();
             _endTurnTcs?.TrySetResult(true);
             _endTurnTcs = null;
+        }
+
+        public void ForceEndTurn()
+        {
+            OnEndTurnClicked();
         }
 
         private void BindPotions()


### PR DESCRIPTION
## Summary
- support cancelling ability selection when ending turn
- add ForceEndTurn and ability checks to `PlayerEntity`
- update HUD to handle forced end turn and cancel ability panel
- rewrite `CombatService` turn processing for multiple player actions per turn

## Testing
- `no tests to run`